### PR TITLE
add repository aaspe-V2

### DIFF
--- a/otterdog/eclipse-aaspe.jsonnet
+++ b/otterdog/eclipse-aaspe.jsonnet
@@ -27,5 +27,20 @@ orgs.newOrg('eclipse-aaspe') {
         default_workflow_permissions: "write",
       },
     },
+    orgs.newRepo('aaspe-V2') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      default_branch: "main",
+      delete_branch_on_merge: false,
+      dependabot_alerts_enabled: false,
+      description: "AASX V2 Package Explorer",
+      secret_scanning: "disabled",
+      secret_scanning_push_protection: "disabled",
+      web_commit_signoff_required: false,
+      workflows+: {
+        actions_can_approve_pull_request_reviews: false,
+        default_workflow_permissions: "write",
+      },
+    },
   ],
 }


### PR DESCRIPTION
We want to separate the development of **AASX V2** Package Explorer from **AASX V3** Package Explorer.
The "V2" and "V3" does not represent the Package Explorer versions but the AAS Metamodel version and the Package Explorer applications differ.
V3 is the current Metamodel version and therefore AASX V3 Package Explorer is our main application at eclipse-aaspe/aaspe.
However, V2 is still relevant to some users, especially in the industry where new versions aren't adapted as fast.
Separating the code into two repositories will add clarity and transparency to the project, allowing us to separate the readmes, issues, releases and so on.